### PR TITLE
Customize jwt functions to use promises 

### DIFF
--- a/server/errors/custom-error.ts
+++ b/server/errors/custom-error.ts
@@ -1,0 +1,13 @@
+class CustomError extends Error {
+  status: number;
+
+  message: string;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.message = message;
+    this.status = status;
+  }
+}
+
+export default CustomError;

--- a/server/errors/index.ts
+++ b/server/errors/index.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+import CustomError from './custom-error';
+
+const clientError = (req: Request, res: Response, next: NextFunction) => {
+  res.status(404).json({ message: 'Page Not Found' });
+};
+
+const serverError = (err: any, req: Request, res: Response, next: NextFunction) => {
+  res
+    .status(err.status || 500)
+    .json({ message: err.status ? err.message : 'Internal Server Error' });
+};
+
+export { clientError, serverError, CustomError };

--- a/server/utils/jwt/index.ts
+++ b/server/utils/jwt/index.ts
@@ -1,0 +1,4 @@
+import verifyToken from './verify-token';
+import signToken from './sign-token';
+
+export { verifyToken, signToken };

--- a/server/utils/jwt/sign-token.ts
+++ b/server/utils/jwt/sign-token.ts
@@ -1,0 +1,8 @@
+const { sign } = require('jsonwebtoken');
+
+export default (userId, username) => new Promise((resolve, reject) => {
+  sign({ userId, username }, process.env.SECRET_KEY, (err, token) => {
+    if (err) return reject(err);
+    return resolve(token);
+  });
+});

--- a/server/utils/jwt/verify-token.ts
+++ b/server/utils/jwt/verify-token.ts
@@ -1,0 +1,8 @@
+import { verify } from 'jsonwebtoken';
+
+export default (token) => new Promise((reject, resolve) => {
+  verify(token, process.env.SECRET_KEY, (err, match) => {
+    if (err) return reject(err);
+    return resolve(match);
+  });
+});


### PR DESCRIPTION
### Create `signToken`, and `verifyToken` functions to use promises instead of callbacks