### PR TITLE
Create SnackBar Component

### DIFF
--- a/client/src/Components/FormUI/Form/index.tsx
+++ b/client/src/Components/FormUI/Form/index.tsx
@@ -3,19 +3,19 @@ import { Formik, Form } from 'formik';
 
 interface CustomFormProps {
   children: ReactNode;
-  initialValue: object;
+  initialValues: object;
   validationSchema: object;
-  onSubmit: (values: object) => void;
+  onSubmit: (values: any) => void;
 }
 
 function CustomForm(props: CustomFormProps) {
   const {
-    children, initialValue, validationSchema, onSubmit,
+    children, initialValues, validationSchema, onSubmit,
   } = props;
 
   return (
     <Formik
-      initialValues={initialValue}
+      initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={onSubmit}
     >

--- a/client/src/Components/FormUI/Input/index.tsx
+++ b/client/src/Components/FormUI/Input/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useField } from 'formik';
-import { TextField, OutlinedTextFieldProps } from '../../../mui';
+import { OutlinedTextFieldProps } from '@mui/material';
+import { TextField } from '../../../mui';
 
 interface InputProps extends OutlinedTextFieldProps {
   name: string;

--- a/client/src/Components/FormUI/Submit/index.tsx
+++ b/client/src/Components/FormUI/Submit/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { useFormikContext } from 'formik';
-import { Button, ButtonProps } from '../../../mui';
+import { ButtonProps } from '@mui/material';
+import { Button } from '../../../mui';
 
 interface SubmitProps extends ButtonProps {
   children: ReactNode;

--- a/client/src/Components/SnackBar/index.tsx
+++ b/client/src/Components/SnackBar/index.tsx
@@ -1,0 +1,53 @@
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
+import { AlertColor } from '@mui/material';
+import { Alert, Snackbar } from '../../mui';
+
+type SnackBarContextActions = {
+  showSnackBar: (text: string, typeColor: AlertColor) => void;
+};
+
+const SnackBarContext = createContext({} as SnackBarContextActions);
+export const useSnackBar = (): SnackBarContextActions => useContext(SnackBarContext);
+
+function SnackBarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>('');
+  const [typeColor, setTypeColor] = useState<AlertColor>('info');
+
+  const showSnackBar = (text: string, color: AlertColor) => {
+    setMessage(text);
+    setTypeColor(color);
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setTypeColor('info');
+  };
+
+  const memoizedSnackBar = useMemo(() => ({ showSnackBar }), []);
+
+  return (
+    <SnackBarContext.Provider value={memoizedSnackBar}>
+      <Snackbar
+        open={open}
+        autoHideDuration={6000}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={handleClose}
+      >
+        <Alert onClose={handleClose} severity={typeColor}>
+          {message}
+        </Alert>
+      </Snackbar>
+      {children}
+    </SnackBarContext.Provider>
+  );
+}
+
+export default SnackBarProvider;

--- a/client/src/Components/SnackBar/index.tsx
+++ b/client/src/Components/SnackBar/index.tsx
@@ -6,14 +6,8 @@ import React, {
   ReactNode,
 } from 'react';
 import { AlertColor } from '@mui/material';
+import { SnackBarContext } from '../../Hooks';
 import { Alert, Snackbar } from '../../mui';
-
-type SnackBarContextActions = {
-  showSnackBar: (text: string, typeColor: AlertColor) => void;
-};
-
-const SnackBarContext = createContext({} as SnackBarContextActions);
-export const useSnackBar = (): SnackBarContextActions => useContext(SnackBarContext);
 
 function SnackBarProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState<boolean>(false);

--- a/client/src/Hooks/index.ts
+++ b/client/src/Hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSnackBar, SnackBarContext } from './snackbar-hook';

--- a/client/src/Hooks/snackbar-hook.ts
+++ b/client/src/Hooks/snackbar-hook.ts
@@ -1,0 +1,11 @@
+import { AlertColor } from '@mui/material';
+import { createContext, useContext } from 'react';
+
+type SnackBarContextActions = {
+  showSnackBar: (text: string, typeColor: AlertColor) => void;
+};
+
+export const SnackBarContext = createContext({} as SnackBarContextActions);
+const useSnackBar = (): SnackBarContextActions => useContext(SnackBarContext);
+
+export default useSnackBar;

--- a/client/src/mui.ts
+++ b/client/src/mui.ts
@@ -2,10 +2,10 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import {
   Button,
-  ButtonProps,
   StyledEngineProvider,
   TextField,
-  OutlinedTextFieldProps,
+  Alert,
+  Snackbar,
 } from '@mui/material';
 
 export {
@@ -15,6 +15,6 @@ export {
   StyledEngineProvider,
   TextField,
   Button,
-  ButtonProps,
-  OutlinedTextFieldProps,
+  Alert,
+  Snackbar,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8621,11 +8621,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/uniqid": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.4.0.tgz",
-      "integrity": "sha512-38JRbJ4Fj94VmnC7G/J/5n5SC7Ab46OM5iNtSstB/ko3l1b5g7ALt4qzHFgGciFkyiRNtDXtLNb+VsxtMSE77A=="
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -15443,10 +15438,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "uniqid": {
-      "version": "https://registry.npmjs.org/uniqid/-/uniqid-5.4.0.tgz",
-      "integrity": "sha512-38JRbJ4Fj94VmnC7G/J/5n5SC7Ab46OM5iNtSstB/ko3l1b5g7ALt4qzHFgGciFkyiRNtDXtLNb+VsxtMSE77A=="
     },
     "universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
## What is Snackbars?
- Snackbars provide brief notifications. The component is also known as a toast

## How to use this generic component?
Wrap the whole app within `SnackBarProvider` so you can use it's context every where in the app:

App.tsx
```tsx
function App() {
  const [codeFormOpen, setCodeFormOpen] = useState<boolean>(true);

  return (
    <SnackBarProvider>
      <PrivateQuizForm
        codeFormOpen={codeFormOpen}
        setCodeFormOpen={setCodeFormOpen}
      />
      Hello, Quizzer!
    </SnackBarProvider>
  );
}
```

Use it in `PrivateQuizForm` by getting the `showSnackBar` function from SnackBar context

PrivateQuizForm.tsx
```tsx
const { showSnackBar } = useSnackBar();
showSnackBar('Invalid Quiz Code', 'error');
```
Now you can use `SnackBars` (alerts/toasts), everywhere in your app.
## Screenshots
- Success

![Screenshot from 2022-05-10 12-49-48](https://user-images.githubusercontent.com/78752405/167605867-7dc147e6-dd67-4b03-8320-41f822d19a9c.png)

- Fail

![Screenshot from 2022-05-10 12-48-33](https://user-images.githubusercontent.com/78752405/167605912-f0cfa971-1b60-4c0b-83cf-ec2634dc1127.png)

For further information on how to use it, refer to [mui docs](https://mui.com/material-ui/react-snackbar)